### PR TITLE
Fix nav bar layout

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -34,7 +34,7 @@ const OPTIONS = {
 
 export const Navbar = () => (
     <div id="nav" className="nav">
-        <ul>
+        <ul className="inline-block">
             {Object.keys(OPTIONS).map(option => <li key={`nav-${OPTIONS[option].label.toLowerCase()}`}><Link to={OPTIONS[option].url}>{OPTIONS[option].label}</Link></li>)}
         </ul>
         <div className="nav-search-icon">

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -16,25 +16,15 @@
     @apply w-full;
     @apply z-20;
     @apply shadow;
-    @apply block;
-    /* @apply flex items-center; */
+    @apply text-lg;
+    @apply flex items-center;
 }
 
 .nav a {
-    @apply float-left;
-    @apply block;
     @apply text-center;
     @apply no-underline;
     @apply font-light;
     @apply text-white hover:text-purple-400;
-    @apply inline-block;
-    @apply p-2;
-}
-
-.nav ul {
-    @apply mt-2 mb-2;
-    @apply ml-5;
-    @apply inline-block;
 }
 
 .nav li {
@@ -43,10 +33,8 @@
 }
 
 .nav-search-icon {
-    @apply inline-block align-baseline;
-    @apply float-right;
-    @apply mr-5;
-    @apply text-white hover:text-purple-400;
+    @apply ml-auto my-2 mr-2;
+    @apply stroke-current text-white hover:text-purple-400;
 }
 
 .hero-image-container {


### PR DESCRIPTION
Fixes the navbar layout

## Changelog
* No longer rely on `float-right` to align search icon
    * Instead, switched to making the navbar container class to display as `flex` PLUS making the nav bar icon class have `auto` for the left margin (`ml-auto`)
    * By using `float`, **it becomes extremely-difficult to vertically-align it to the middle**
        * Float always sets the component to `top-0`, so it will override vertical alignment
* Simplify the navbar CSS classes
* Align navbar items vertically with `items-center` (requires `flex`)