### PR TITLE
Improve blog article layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,12 @@ This started happening after implementing `react-redux`, specifically after addi
 Strangely, this doesn't seem to affect all images; just the ones on the home page. The images in the blog feed always seem to update to the full resolution. The only difference between these two image sets is that the blog feed images come from Sanity plugin and the home page images from the local filesystem plugin.
 
 **UPDATE:** This _does_ appear to work, albeit after a significant delay. I left the home page up for a couple of minutes, after which the images finally resolved to the full-res versions. _It seems that the issue is simply that locally-sourced images will take a long time to finish loading, at least when it comes to local development; this is untested on a build as of yet._
+
+### Sanity - Internal link serialization doesn't expose slug data for related records
+According to the Sanity documentation, we should be able to get a slug to the internal document using `const {slug = {}} = props.mark`. However, it seems this only works if you query the data using GROQ. Since Gatsby sites are sourced using GraphQL, and since the Sanity GraphQL API doesn't appear to return the correct data for the `@sanity/block-content-to-react`, **it doesn't currently appear to be possible to use serializers to setup internal links for a Gatsby site**.
+* Gatsby nodes are sourced using GraphQL queries during the site build process
+    * Unless there is some way to "inject" GROQ data, internal links can only be supported by adding them as "external" links (you'll need to provide the full URL to the would-be page location in the article)
+
+As it currently stands, we can only get the internal ID of the reference. We may be able to use this by querying the data using GROQ when the user accesses the page, but this is not ideal:
+* It's an extra step to render the page
+* It would require developers to understand both GraphQL and GROQ (plus how/why you need to use one versus the other - not easy to do if unfamiliar with Sanity)

--- a/docs/Repository Information/sanity.io/BlockContent and Serializers.md
+++ b/docs/Repository Information/sanity.io/BlockContent and Serializers.md
@@ -1,0 +1,29 @@
+# Sanity.io - BlockContent and Serializers
+
+In Sanity, "rich text" fields are implemented in the schema as an array of blocks (which is all defined and stored internally at Sanity.io). 
+
+When consuming the data from Sanity, the application needs to know how to serialize the blocks to the correct content. This document covers the "how" and "why" of serializers in this repository.
+
+In the context of the `creators-blog`, one such field is the article `body` field. **Although you can query the `body` field in GraphQL, you should always use the `_raw` version of the text field. In our case, this is `_rawBody`.**
+
+## Why `_raw`?
+In short, because it's way harder to use the non-raw version of the field for a number of reasons:
+* There is no "convenience" logic to interpret each block as the correct type (e.g., `p`, `strong`, `span`, etc.)
+    * In some cases, there are fields you can use to achieve the same result, but you have to perform a lot of manual logic to extract only the necessary/usable fields
+* Sanity uses the [Portable Text](https://github.com/portabletext/portabletext) specification
+    * Because of this, we can use the provided [`@sanity/block-content-to-react`](https://www.sanity.io/docs/portable-text-to-react) package to simply consume the `_rawBody` field and convert the blocks to site content
+
+## Portable Text and `@sanity/block-content-to-react`
+The `@sanity/block-content-to-react` provides the `BlockContent` component, which requires the `blocks` field - this is where we pass the raw body. For example:
+```tsx
+<BlockContent blocks={_rawBody} serializers={serializers}/>
+```
+
+There is no need to manually process **any** of the body content because `BlockContent` handles that for you. **You will need to create serializers for any "custom" or non-default fields that the target block content has**. Some examples that this repository uses:
+1. `types.code` - Tells `BlockContent` how to render code blocks
+2. `marks.highlight` - Tells `BlockContent` how to render highlighted text
+3. `marks.internalLink` - Tells `BlockContent` what to do when an internal link is encountered*
+    * _Internal links are not supported in Gatsby sites out-of-the-box; the Sanity GraphQL API doesn't return any slug data, which is required to link the internal resources on the Gatsby side of things_
+4. `marks.link` - Tells `BlockContent` what to do when an internal link is encountered
+
+> NOTE: Don't leave empty, yet supported, fields in the serializers object. For example, `list` is a supported field on a serializer object for Sanity, but if you were have this in your serializer object while set to `{}`, your site will not build (and the error isn't really clear). I assume the same goes for any other supported field in serializers. **TL;DR: only add what you need to the serializers object**

--- a/src/components/blog/CategoryFilterLabel.tsx
+++ b/src/components/blog/CategoryFilterLabel.tsx
@@ -11,7 +11,7 @@ import { addActiveCategory, removeActiveCategory } from '../../slices/blogFeedSl
  *                  except in the blog feed filter, where they are inactive until the user toggles them.
  * @returns 
  */
-export const CategoryLabel = ({ 
+export const CategoryFilterLabel = ({ 
     label, 
 }: { 
     label: string, 

--- a/src/components/blog/EmbeddedCategoryLabel.tsx
+++ b/src/components/blog/EmbeddedCategoryLabel.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { addActiveCategory, removeActiveCategory } from '../../slices/blogFeedSlice'
+
+/**
+ * Category label
+ * 
+ * This component is used in the Blog feed filter and on the article rows.
+ * 
+ * @param isActive  indicates whether or not to use the "active" version, which is the default for most cases
+ *                  except in the blog feed filter, where they are inactive until the user toggles them.
+ * @returns 
+ */
+export const EmbeddedCategoryFilterLabel = ({ 
+    label, 
+}: { 
+    label: string, 
+}) => {
+    const activeCategories = useSelector((state: any) => state.blog.activeCategories)
+    const dispatch = useDispatch()
+    return (
+        <div className={`embedded-category-label`}
+            onClick={() => {
+                if (activeCategories.includes(label)) {
+                    dispatch(removeActiveCategory(label))
+                } else {
+                    dispatch(addActiveCategory(label))
+                }
+            }}
+        >
+            <p>{label}</p>
+        </div>
+    )
+}

--- a/src/components/blog/FilterModal.tsx
+++ b/src/components/blog/FilterModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { setFilterText } from '../../slices/blogFeedSlice'
-import { CategoryLabel } from './CategoryLabel'
+import { CategoryFilterLabel } from './CategoryFilterLabel'
 
 export const FilterModal = ({ 
     categories,
@@ -35,8 +35,8 @@ export const FilterModal = ({
                     onClick={() => dispatch(setFilterText(``))}
                 >clear text</button>
             </div>
-            <div className="modal-category-grid">
-                {categories.map(cat => <CategoryLabel label={cat}/>)}
+            <div className="category-grid">
+                {categories.map(cat => <CategoryFilterLabel label={cat}/>)}
             </div>
             <div className="modal-footer">
                 <p>

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -191,10 +191,6 @@ h1 {
     @apply z-40;
     @apply bg-white;
 }
-.modal-category-grid {
-    @apply grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4;
-    @apply m-10;
-}
 .modal-filter-by-text-field {
     @apply text-center;
     @apply mb-2;
@@ -206,6 +202,20 @@ h1 {
     @apply w-3/4;
     @apply text-justify text-gray-400 italic;
     @apply mx-auto mb-4;
+}
+
+.category-grid {
+    @apply grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4;
+    @apply m-10;
+}
+.embedded-category-grid {
+    @apply grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4;
+    @apply mt-4;
+}
+.embedded-category-label {
+    @apply border rounded-full py-1 px-2 border-purple-500 text-purple-500;
+    @apply block align-middle text-center text-xs;
+    @apply bg-purple-100;
 }
 
 .category-label {
@@ -225,35 +235,36 @@ h1 {
 }
 
 .article-detail {
-    @apply flex;
     @apply mb-6;
 }
 .article-detail h1 {
     @apply text-5xl;
     @apply font-light;
 }
-.article-detail p {
-    @apply ml-auto;
+.article-detail > p {
     @apply text-gray-500 italic;
 }
 
 .article-body {
-    @apply text-lg;
+    @apply text-lg leading-relaxed;
 }
-.article-body p {
-    @apply my-2;
+.article-body > div > p {
+    @apply my-6;
+}
+.article-body h1, h2 {
+    @apply text-purple-900;
 }
 .article-body h1 {
-    @apply text-3xl;
+    @apply text-4xl;
 }
 .article-body h2 {
-    @apply text-2xl;
+    @apply text-3xl;
 }
 .article-body a {
     @apply text-purple-500 hover:text-purple-800;
 }
 .article-body blockquote {
-    @apply border-l-4 pl-4 my-4 w-11/12 mx-auto;
+    @apply border-l-4 px-4 my-4 w-11/12 mx-auto;
     @apply border-gray-400;
     @apply bg-gray-100 text-gray-600 py-2;
     @apply italic;
@@ -276,7 +287,7 @@ h1 {
 }
 .article-body ul > li > ul {
     list-style-type: square;
-    @apply my-2 ml-4;
+    @apply my-2 ml-4 pl-2;
 }
 .article-body ol {
     @apply list-decimal;

--- a/src/serializers.tsx
+++ b/src/serializers.tsx
@@ -1,7 +1,17 @@
 import React from 'react'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 
+/**
+ * @see https://www.sanity.io/docs/portable-text-to-react#proptypes
+ */
 const serializers = {
+    container: ({ children }) => {
+        return (
+            children.map(block => {
+                return (<div key={`${block.key}`}>{block}</div>)
+            })
+        )
+    },
     types: {
         code: props => {
             const { language, code } = props.node
@@ -11,8 +21,25 @@ const serializers = {
         },
     },
     marks: {
-        highlight: ({ children }) => <span className="bg-yellow-200 p-1 rounded">{children}</span>
-    }
+        highlight: ({ children }) => <span className="bg-yellow-200 p-1 rounded">{children}</span>,
+        internalLink: (props) => {
+            console.error(`Sanity internal links are not currently supported in GraphQL-sourced data - convert the internal link to an external link as a temporary workaround`)
+            return <a href={`#`}>{props.children}</a>
+          },
+        link: ({ mark, children }) => {
+            return (
+                <a href={mark.url} target="_blank">
+                    {children}
+                </a>
+            )
+        }
+    },
+    // list: {
+
+    // },
+    // listItem: {
+
+    // }
 }
 
 export default serializers

--- a/src/templates/blogArticle.tsx
+++ b/src/templates/blogArticle.tsx
@@ -4,6 +4,7 @@ import { Layout } from "../components/Layout"
 import { GatsbyImage } from 'gatsby-plugin-image'
 import BlockContent from '@sanity/block-content-to-react'
 import serializers from '../serializers'
+import { EmbeddedCategoryFilterLabel } from '../components/blog/EmbeddedCategoryLabel'
 
 export const query = graphql`
 query($slug: String!){
@@ -40,10 +41,19 @@ const BlogArticle = ({ pageContext, data }) => {
             <div className="article">
                 <div className="article-detail">
                     <h1>{title}</h1>
-                    <p>{publishDate}</p>
+                    <p className="mt-2">{publishDate}</p>
+                        {categories.length > 0 ? 
+                            <div className="embedded-category-grid">
+                                {categories.map(cat => (
+                                    <div key={`embedded-category-${cat.title}`}>
+                                        <EmbeddedCategoryFilterLabel label={cat.title}/>
+                                    </div>
+                                ))}
+                            </div>
+                        : null }
                 </div>
                 <div className="article-body">
-                    <BlockContent blocks={_rawBody} serializers={serializers}/>
+                    <BlockContent className={`block-content`} blocks={_rawBody} serializers={serializers}/>
                 </div>
             </div>
         </Layout>


### PR DESCRIPTION
This PR updates the Blog article layout quite a bit and makes sure there are no errors in the console, **aside from the error related to internal links**.

Internal links from Sanity don't seem to map to the correct fields when queried through GraphQL, which is a bit of a limitation. Unfortunately, the only workaround appears to be to simply not use internal links.

This PR also adds some docs.